### PR TITLE
feat: use 'in progress' label and handle auto-removal #5

### DIFF
--- a/.issues/CLOSED/005-update-in-progress-label.md
+++ b/.issues/CLOSED/005-update-in-progress-label.md
@@ -1,0 +1,12 @@
+---
+title: Update In Progress Label
+status: CLOSED
+---
+
+## Description
+Update the sync script to use the specific "in progress" label (with a space) as requested by the user, and ensure it is removed when an issue is no longer in progress.
+
+## Tasks
+- [x] Update `scripts/sync-issues.mjs` to use "in progress" label
+- [x] Implement logic to remove "in progress" when status is not `IN_PROGRESS`
+- [x] Verify logic and close issue

--- a/.issues/CLOSED/005-update-in-progress-label.md
+++ b/.issues/CLOSED/005-update-in-progress-label.md
@@ -1,8 +1,8 @@
 ---
 title: Update In Progress Label
 status: CLOSED
+gh_number: 8
 ---
-
 ## Description
 Update the sync script to use the specific "in progress" label (with a space) as requested by the user, and ensure it is removed when an issue is no longer in progress.
 

--- a/scripts/sync-issues.mjs
+++ b/scripts/sync-issues.mjs
@@ -153,8 +153,11 @@ const sync = async () => {
     } else {
       console.log(`Updating issue #${gh_number}...`);
       const labels = Array.isArray(attributes.labels) ? [...attributes.labels] : []
-      if (status === 'IN_PROGRESS' && !labels.includes('in-progress')) {
-        labels.push('in-progress')
+      if (status === 'IN_PROGRESS') {
+        if (!labels.includes('in progress')) labels.push('in progress')
+      } else {
+        const index = labels.indexOf('in progress')
+        if (index > -1) labels.splice(index, 1)
       }
 
       const result = await atomicAsync(() => octokit.issues.update({

--- a/scripts/sync-issues.mjs
+++ b/scripts/sync-issues.mjs
@@ -129,8 +129,11 @@ const sync = async () => {
     if (!gh_number) {
       console.log(`Creating issue for ${file}...`);
       const labels = Array.isArray(attributes.labels) ? [...attributes.labels] : []
-      if (status === 'IN_PROGRESS' && !labels.includes('in-progress')) {
-        labels.push('in-progress')
+      if (status === 'IN_PROGRESS') {
+        if (!labels.includes('in progress')) labels.push('in progress')
+      } else {
+        const index = labels.indexOf('in progress')
+        if (index > -1) labels.splice(index, 1)
       }
 
       const result = await atomicAsync(() => octokit.issues.create({


### PR DESCRIPTION
## Description
This PR updates the `sync-issues.mjs` script to use the user-defined `in progress` label (with a space) and adds logic to automatically remove it when an issue is no longer in that state.

## Changes
- [x] Switched `in-progress` to `in progress` labels.
- [x] Added logic to remove `in progress` when status is `OPEN` or `CLOSED`.
- [x] Updated issue #5 to `CLOSED` and moved it to the correct folder.

Closes #5