### PR TITLE
fix: ensure 'in progress' label is synced by preserving existing labels #7

### DIFF
--- a/.issues/OPEN/007-test-rejection.md
+++ b/.issues/OPEN/007-test-rejection.md
@@ -1,10 +1,8 @@
 ---
 title: Test Rejection Verification
-status: CLOSED
+status: OPEN
 gh_number: 7
-test_ref: src/logic/progress.test.ts
 ---
-
 ## Description
 This is a proof-of-concept issue to verify that the sync script correctly rejects a 'CLOSED' state when tests fail, and instead promotes the issue to 'IN_PROGRESS' with the appropriate label.
 

--- a/.issues/OPEN/007-test-rejection.md
+++ b/.issues/OPEN/007-test-rejection.md
@@ -1,8 +1,10 @@
 ---
 title: Test Rejection Verification
-status: OPEN
+status: CLOSED
 gh_number: 7
+test_ref: src/logic/progress.test.ts
 ---
+
 ## Description
 This is a proof-of-concept issue to verify that the sync script correctly rejects a 'CLOSED' state when tests fail, and instead promotes the issue to 'IN_PROGRESS' with the appropriate label.
 

--- a/scripts/sync-issues.mjs
+++ b/scripts/sync-issues.mjs
@@ -152,7 +152,21 @@ const sync = async () => {
       }
     } else {
       console.log(`Updating issue #${gh_number}...`);
-      const labels = Array.isArray(attributes.labels) ? [...attributes.labels] : []
+      
+      // Fetch existing issue to preserve other labels
+      const existingIssue = await atomicAsync(() => octokit.issues.get({
+        owner,
+        repo,
+        issue_number: gh_number
+      }));
+
+      let labels = []
+      if (existingIssue.ok) {
+        labels = existingIssue.value.data.labels.map(l => typeof l === 'string' ? l : l.name)
+      } else {
+        labels = Array.isArray(attributes.labels) ? [...attributes.labels] : []
+      }
+
       if (status === 'IN_PROGRESS') {
         if (!labels.includes('in progress')) labels.push('in progress')
       } else {


### PR DESCRIPTION
## Description
This PR fixes the issue where the `in progress` label was not being applied to redirected issues (Issues that failed TDD and moved to `IN_PROGRESS`).

## Changes
- [x] **Label Preservation**: The sync script now fetches existing labels from GitHub before updating, ensuring that we don't wipe other labels and that the `in progress` label is accurately added/removed.
- [x] **Metadata Restoration**: Restored the `test_ref` to Issue #7 and set its status to `CLOSED` to re-trigger the TDD verification.

Closes #7